### PR TITLE
Removing a force-unwrap

### DIFF
--- a/Sources/Screenshots/UIView+Additions.swift
+++ b/Sources/Screenshots/UIView+Additions.swift
@@ -3,15 +3,13 @@ import UIKit
 
 extension UIView {
     func screenshotForCroppingRect(croppingRect: CGRect) -> UIImage? {
-
         UIGraphicsBeginImageContextWithOptions(croppingRect.size, false, UIScreen.main.scale)
 
-        let context = UIGraphicsGetCurrentContext()
-        if context == nil {
+        guard let context = UIGraphicsGetCurrentContext() else {
             return nil
         }
 
-        context!.translateBy(x: -croppingRect.origin.x, y: -croppingRect.origin.y)
+        context.translateBy(x: -croppingRect.origin.x, y: -croppingRect.origin.y)
         self.layoutIfNeeded()
         self.layer.render(in: context!)
 


### PR DESCRIPTION
Avoiding a force-unwrap by using a `guard` statement.